### PR TITLE
update 3.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: e4b68bb881802dda1a7d878b2fc84c06d1ee57fb40b874d3dc97dabfa36b8312
 
 build:
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -19,11 +19,10 @@ requirements:
   host:
     - python
     - pip
-    - pdm-pep517 >=1.0.0
-    - flit-core
+    - flit-core <4
   run:
     - python
-    - flask >=2.2
+    - flask >=2.2.5
     - sqlalchemy >=1.4.18
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - flask >=2.2.5
-    - sqlalchemy >=1.4.18
+    - sqlalchemy >=2.0.16
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,27 +1,26 @@
 {% set name = "Flask-SQLAlchemy" %}
-{% set version = "3.0.2" %}
-
+{% set version = "3.1.1" %}
+{% set file_name = "flask_sqlalchemy" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 16199f5b3ddfb69e0df2f52ae4c76aedbfec823462349dabb21a1b2e0a2b65e9
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ file_name }}-{{ version }}.tar.gz
+  sha256: e4b68bb881802dda1a7d878b2fc84c06d1ee57fb40b874d3dc97dabfa36b8312
 
 build:
   skip: True  # [py<37]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - python
     - pip
     - pdm-pep517 >=1.0.0
-    - setuptools
-    - wheel
+    - flit-core
   run:
     - python
     - flask >=2.2


### PR DESCRIPTION
flask-sqlalchemy 3.1.1

**Destination channel:** defaults

### Links

- [PKG-3393](https://anaconda.atlassian.net/browse/PKG-3393) 
- [Upstream repository](https://github.com/pallets-eco/flask-sqlalchemy)
- [Upstream changelog/diff](https://github.com/pallets-eco/flask-sqlalchemy/releases/tag/3.1.1)

### Explanation of changes:

- flit-core added
- alter url getting


[PKG-3393]: https://anaconda.atlassian.net/browse/PKG-3393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ